### PR TITLE
Add about:config firefox troubleshooting

### DIFF
--- a/docs/0100-tech/130-workstation/010-common.md
+++ b/docs/0100-tech/130-workstation/010-common.md
@@ -128,3 +128,17 @@ You must keep firefox-csshacks up to data to keep this working.
   ```
 
 - You can change the `--uc-sidebar-width` and `--uc-sidebar-hover-width` values to your liking
+
+#### Troubleshooting
+
+##### Translation target languages stuck
+
+If Firefox Translation keeps defaulting to unwanted languages, reset the `browser.translations.mostRecentTargetLanguages` preference:
+
+1. Open `about:config` in the address bar and accept the advanced configuration warning.
+2. Search for `browser.translations.mostRecentTargetLanguages`.
+3. Click the pencil icon to edit the value.
+4. Remove any two-letter language codes you do not want (e.g., `ES`, `RU`) and keep only the ones you prefer (e.g., `EN`).
+5. Save the preference with the checkmark, restart Firefox, and confirm the translation menu reflects the change.
+
+Source: [Reddit](https://www.reddit.com/r/firefox/comments/1k2bqkn/comment/n75tcjf/)


### PR DESCRIPTION
Add a Firefox troubleshooting entry for resetting `browser.translations.mostRecentTargetLanguages` via `about:config` to address unwanted translation targets.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7ae7b9b-f9fa-464f-ac0e-651c1fd7b0c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7ae7b9b-f9fa-464f-ac0e-651c1fd7b0c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

