### PR TITLE
Remove trailing dash from photography post-processing docs

### DIFF
--- a/docs/0140-photography-and-cinematography/030-picture-post-processing/index.md
+++ b/docs/0140-photography-and-cinematography/030-picture-post-processing/index.md
@@ -11,7 +11,6 @@ Most of the items in here should be changed in the way that best serves the stor
 - [This document](https://studentcabletelevision.com/wp-content/uploads/2018/05/Color-Grading-Guide-Updated-Spring-2018.pdf) ([web archive link](https://web.archive.org/web/20231220082026/https://studentcabletelevision.com/wp-content/uploads/2018/05/Color-Grading-Guide-Updated-Spring-2018.pdf)) for getting a better understanding of terminology and concepts.
 - [Scott Kelby's Lightroom 7-Point System](https://www.goodreads.com/book/show/57951601-scott-kelby-s-lightroom-7-point-system) As a beginner, this books helped me to create my workflow and know different techniques to achieve the desired look.
 - [This video](https://www.youtube.com/watch?v=KNFaqwk8-ps) had a good example for the post-processing process.
--
 
 ## The Process
 


### PR DESCRIPTION
## Summary
Removed a stray trailing dash character from the picture post-processing documentation.

## Changes
- Removed extraneous dash (`-`) that appeared at the end of the resources list in the photography and cinematography post-processing guide

## Details
This was a minor cleanup of a formatting artifact in the markdown documentation. The dash served no purpose and has been removed to improve the document's cleanliness.

https://claude.ai/code/session_01QtxvUxvtVMJgBkSKbx6fJ6